### PR TITLE
Log RPC requests and responses when in debug mode

### DIFF
--- a/client.go
+++ b/client.go
@@ -214,7 +214,12 @@ func (c *Client) Call(method string, params interface{}, result interface{}) (er
 		token.setToken(c.auth.token)
 	}
 
-	return c.rpcConn.Call(c.ctx, method, params, result)
+	call := c.rpcConn.Call(c.ctx, method, params, result)
+	if c.debugMode {
+		log.Printf("Request: %v %#v", method, params)
+		log.Printf("Response: %#v", result)
+	}
+	return call
 }
 
 // Handle implements jsonrpc2.Handler


### PR DESCRIPTION
Useful for troubleshooting potential issues.

Example log:
```
2021/01/17 15:46:53 Request: public/set_heartbeat &models.SetHeartbeatParams{Interval:30}
2021/01/17 15:46:53 Response: (*string)(0xc0004f9e80)
2021/01/17 15:46:53 Request: public/test json.RawMessage{0x7b, 0x7d}
2021/01/17 15:46:53 Response: &models.TestResponse{Version:"1.2.26"}
2021/01/17 15:46:53 Request: public/subscribe &models.SubscribeParams{Channels:[]string{"quote.BTC-PERPETUAL"}}
2021/01/17 15:46:53 Response: &models.SubscribeResponse{"quote.BTC-PERPETUAL"}
2021/01/17 15:46:53 Channel: quote.BTC-PERPETUAL {"timestamp":1610898413841,"instrument_name":"BTC-PERPETUAL","best_bid_price":35829.5,"best_bid_amount":180.0,"best_ask_price":35830.0,"best_ask_amount":72260.0}
2021/01/17 15:46:54 Channel: quote.BTC-PERPETUAL {"timestamp":1610898414898,"instrument_name":"BTC-PERPETUAL","best_bid_price":35829.5,"best_bid_amount":180.0,"best_ask_price":35830.0,"best_ask_amount":5000.0}
```