### PR TITLE
add Label field to user_trade

### DIFF
--- a/api_trading.go
+++ b/api_trading.go
@@ -84,6 +84,11 @@ func (c *Client) GetOrderState(params *models.GetOrderStateParams) (result model
 	return
 }
 
+func (c *Client) GetOrderStateByLabel(params *models.GetOrderStateByLabelParams) (result []models.Order, err error) {
+	err = c.Call("/private/get_order_state_by_label", params, &result)
+	return
+}
+
 func (c *Client) GetStopOrderHistory(params *models.GetStopOrderHistoryParams) (result models.GetStopOrderHistoryResponse, err error) {
 	err = c.Call("private/get_stop_order_history", params, &result)
 	return

--- a/api_trading.go
+++ b/api_trading.go
@@ -104,7 +104,7 @@ func (c *Client) GetUserTradesByInstrumentAndTime(params *models.GetUserTradesBy
 	return
 }
 
-func (c *Client) GetUserTradesByOrder(params *models.GetUserTradesByOrderParams) (result models.GetUserTradesResponse, err error) {
+func (c *Client) GetUserTradesByOrder(params *models.GetUserTradesByOrderParams) (result []models.Trade, err error) {
 	err = c.Call("private/get_user_trades_by_order", params, &result)
 	return
 }

--- a/api_trading.go
+++ b/api_trading.go
@@ -109,7 +109,7 @@ func (c *Client) GetUserTradesByInstrumentAndTime(params *models.GetUserTradesBy
 	return
 }
 
-func (c *Client) GetUserTradesByOrder(params *models.GetUserTradesByOrderParams) (result models.GetUserTradesResponse, err error) {
+func (c *Client) GetUserTradesByOrder(params *models.GetUserTradesByOrderParams) (result []models.Trade, err error) {
 	err = c.Call("private/get_user_trades_by_order", params, &result)
 	return
 }

--- a/api_trading.go
+++ b/api_trading.go
@@ -39,6 +39,11 @@ func (c *Client) CancelAllByInstrument(params *models.CancelAllByInstrumentParam
 	return
 }
 
+func (c *Client) CancelByLabel(params *models.CancelByLabelParams) (result int, err error) {
+	err = c.Call("private/cancel_by_label", params, &result)
+	return
+}
+
 func (c *Client) ClosePosition(params *models.ClosePositionParams) (result models.ClosePositionResponse, err error) {
 	err = c.Call("private/close_position", params, &result)
 	return

--- a/client_test.go
+++ b/client_test.go
@@ -2,9 +2,10 @@ package deribit
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/frankrap/deribit-api/models"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func newClient() *Client {
@@ -133,6 +134,39 @@ func TestClient_Buy(t *testing.T) {
 		return
 	}
 	t.Logf("%#v", result)
+}
+
+func TestClient_CancelByLabel(t *testing.T) {
+	client := newClient()
+	params := &models.BuyParams{
+		InstrumentName: "BTC-PERPETUAL",
+		Amount:         10,
+		Price:          20000.0,
+		Type:           "limit",
+		Label:          "TestClient_CancelByLabel",
+	}
+	result, err := client.Buy(params)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	t.Logf("%#v", result)
+
+	cancelByLabelParams := &models.CancelByLabelParams{
+		Label: "TestClient_CancelByLabel",
+	}
+
+	cancelResult, err := client.CancelByLabel(cancelByLabelParams)
+	if err != nil {
+		t.Errorf("Cancel failed, %s", err)
+	}
+
+	if cancelResult <= 0 {
+		t.Errorf("Cancel order count should be greater than 0, actual=%d", cancelResult)
+	}
+
+	t.Logf("%#v", cancelResult)
 }
 
 func TestJsonOmitempty(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -70,8 +70,10 @@ func TestClient_GetInstruments_future(t *testing.T) {
 		assert.NotEmpty(t, instrument.CounterCurrency)
 		assert.NotEmpty(t, instrument.CreationTimestamp)
 		assert.NotEmpty(t, instrument.ExpirationTimestamp)
+		assert.NotEmpty(t, instrument.SettlementCurrency)
 		assert.NotEmpty(t, instrument.Kind)
 		assert.Truef(t, instrument.CounterCurrency == "BTC" || instrument.BaseCurrency == "BTC", "%+v", instrument)
+		assert.Truef(t, instrument.SettlementCurrency == "BTC", "%+v", instrument)
 		assert.Equal(t, instrument.Kind, "future")
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -169,6 +169,56 @@ func TestClient_CancelByLabel(t *testing.T) {
 	t.Logf("%#v", cancelResult)
 }
 
+func TestClient_GetUserTradesByOrder(t *testing.T) {
+	client := newClient()
+	params := &models.BuyParams{
+		InstrumentName: "BTC-PERPETUAL",
+		Amount:         10,
+		Price:          20000.0,
+		Type:           "market",
+		Label:          "TestClient_CancelByLabel",
+	}
+	buyResult, err := client.Buy(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("%#v", buyResult)
+
+	getTradesRes, err := client.GetUserTradesByOrder(&models.GetUserTradesByOrderParams{OrderID: buyResult.Order.OrderID})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if actualTradesCount := len(getTradesRes); actualTradesCount == 0 {
+		t.Errorf("no Trades")
+	}
+
+	if expectTradesCount, actualTradesCount := len(buyResult.Trades), len(getTradesRes); expectTradesCount != actualTradesCount {
+		t.Fatalf("Expected trades count %d, actual: %d", expectTradesCount, actualTradesCount)
+	}
+
+	for i, trade := range buyResult.Trades {
+		if trade.TradeSeq != getTradesRes[i].TradeSeq {
+			t.Errorf("Expected TradeSeq %d, actual %d", trade.TradeSeq, getTradesRes[i].TradeSeq)
+		}
+
+		if trade.TradeID != getTradesRes[i].TradeID {
+			t.Errorf("Expected TradeID %s, actual %s", trade.TradeID, getTradesRes[i].TradeID)
+		}
+
+		if trade.Amount != getTradesRes[i].Amount {
+			t.Errorf("Expected Amount %f, actual %f", trade.Amount, getTradesRes[i].Amount)
+		}
+
+		if trade.Price != getTradesRes[i].Price {
+			t.Errorf("Expected Price %f, actual %f", trade.Price, getTradesRes[i].Price)
+		}
+	}
+
+}
+
 func TestJsonOmitempty(t *testing.T) {
 	params := &models.BuyParams{
 		InstrumentName: "BTC-PERPETUAL",

--- a/client_test.go
+++ b/client_test.go
@@ -38,6 +38,44 @@ func TestClient_Test(t *testing.T) {
 	t.Logf("%v", result)
 }
 
+func TestClient_GetInstruments_spot(t *testing.T) {
+	client := newClient()
+	instruments, err := client.GetInstruments(&models.GetInstrumentsParams{Currency: "BTC", Kind: "spot"})
+	assert.Nil(t, err)
+	assert.True(t, len(instruments) > 0, "No instrument gotten")
+	for _, instrument := range instruments {
+		assert.NotEmpty(t, instrument.InstrumentName)
+		assert.NotEmpty(t, instrument.BaseCurrency)
+		assert.NotEmpty(t, instrument.ContractSize)
+		assert.NotEmpty(t, instrument.InstrumentType)
+		assert.NotEmpty(t, instrument.CounterCurrency)
+		assert.NotEmpty(t, instrument.CreationTimestamp)
+		assert.NotEmpty(t, instrument.ExpirationTimestamp)
+		assert.NotEmpty(t, instrument.Kind)
+		assert.Truef(t, instrument.CounterCurrency == "BTC" || instrument.BaseCurrency == "BTC", "%+v", instrument)
+		assert.Equal(t, instrument.Kind, "spot")
+	}
+}
+
+func TestClient_GetInstruments_future(t *testing.T) {
+	client := newClient()
+	instruments, err := client.GetInstruments(&models.GetInstrumentsParams{Currency: "BTC", Kind: "future"})
+	assert.Nil(t, err)
+	assert.True(t, len(instruments) > 0, "No instrument gotten")
+	for _, instrument := range instruments {
+		assert.NotEmpty(t, instrument.InstrumentName)
+		assert.NotEmpty(t, instrument.BaseCurrency)
+		assert.NotEmpty(t, instrument.ContractSize)
+		assert.NotEmpty(t, instrument.InstrumentType)
+		assert.NotEmpty(t, instrument.CounterCurrency)
+		assert.NotEmpty(t, instrument.CreationTimestamp)
+		assert.NotEmpty(t, instrument.ExpirationTimestamp)
+		assert.NotEmpty(t, instrument.Kind)
+		assert.Truef(t, instrument.CounterCurrency == "BTC" || instrument.BaseCurrency == "BTC", "%+v", instrument)
+		assert.Equal(t, instrument.Kind, "future")
+	}
+}
+
 func TestClient_GetBookSummaryByCurrency(t *testing.T) {
 	client := newClient()
 	params := &models.GetBookSummaryByCurrencyParams{

--- a/client_test.go
+++ b/client_test.go
@@ -2,9 +2,10 @@ package deribit
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/frankrap/deribit-api/models"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func newClient() *Client {
@@ -133,6 +134,56 @@ func TestClient_Buy(t *testing.T) {
 		return
 	}
 	t.Logf("%#v", result)
+}
+
+func TestClient_GetUserTradesByOrder(t *testing.T) {
+	client := newClient()
+	params := &models.BuyParams{
+		InstrumentName: "BTC-PERPETUAL",
+		Amount:         10,
+		Price:          20000.0,
+		Type:           "market",
+		Label:          "TestClient_CancelByLabel",
+	}
+	buyResult, err := client.Buy(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("%#v", buyResult)
+
+	getTradesRes, err := client.GetUserTradesByOrder(&models.GetUserTradesByOrderParams{OrderID: buyResult.Order.OrderID})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if actualTradesCount := len(getTradesRes); actualTradesCount == 0 {
+		t.Errorf("no Trades")
+	}
+
+	if expectTradesCount, actualTradesCount := len(buyResult.Trades), len(getTradesRes); expectTradesCount != actualTradesCount {
+		t.Fatalf("Expected trades count %d, actual: %d", expectTradesCount, actualTradesCount)
+	}
+
+	for i, trade := range buyResult.Trades {
+		if trade.TradeSeq != getTradesRes[i].TradeSeq {
+			t.Errorf("Expected TradeSeq %d, actual %d", trade.TradeSeq, getTradesRes[i].TradeSeq)
+		}
+
+		if trade.TradeID != getTradesRes[i].TradeID {
+			t.Errorf("Expected TradeID %s, actual %s", trade.TradeID, getTradesRes[i].TradeID)
+		}
+
+		if trade.Amount != getTradesRes[i].Amount {
+			t.Errorf("Expected Amount %f, actual %f", trade.Amount, getTradesRes[i].Amount)
+		}
+
+		if trade.Price != getTradesRes[i].Price {
+			t.Errorf("Expected Price %f, actual %f", trade.Price, getTradesRes[i].Price)
+		}
+	}
+
 }
 
 func TestJsonOmitempty(t *testing.T) {

--- a/models/cancel_by_label.go
+++ b/models/cancel_by_label.go
@@ -1,0 +1,6 @@
+package models
+
+type CancelByLabelParams struct {
+	Label    string `json:"label"`
+	Currency string `json:"currency,omitempty"`
+}

--- a/models/get_order_state_by_label.go
+++ b/models/get_order_state_by_label.go
@@ -1,0 +1,6 @@
+package models
+
+type GetOrderStateByLabelParams struct {
+	Currency string `json:"currency"`
+	Label    string `json:"label"`
+}

--- a/models/instrument.go
+++ b/models/instrument.go
@@ -16,4 +16,5 @@ type Instrument struct {
 	BaseCurrency        string  `json:"base_currency"`
 	CounterCurrency     string  `json:"counter_currency"`
 	InstrumentType      string  `json:"instrument_type"`
+	SettlementCurrency  string  `json:"settlement_currency"`
 }

--- a/models/instrument.go
+++ b/models/instrument.go
@@ -14,4 +14,6 @@ type Instrument struct {
 	CreationTimestamp   int64   `json:"creation_timestamp"`
 	ContractSize        float64 `json:"contract_size"`
 	BaseCurrency        string  `json:"base_currency"`
+	CounterCurrency     string  `json:"counter_currency"`
+	InstrumentType      string  `json:"instrument_type"`
 }

--- a/models/user_trade.go
+++ b/models/user_trade.go
@@ -18,4 +18,5 @@ type UserTrade struct {
 	Fee            float64     `json:"fee"`
 	Direction      string      `json:"direction"`
 	Amount         float64     `json:"amount"`
+	Label          string      `json:"label"`
 }


### PR DESCRIPTION
Deribit Doc missed a "label" field on user.trade.xxx event data. The "label" contains corresponding `label` parameter of the buy/sell request.

Since user.trades.xxx event is earlier than user.orders.xxx, handling by `label` is more efficient.

Here is the log to show that the field exists.

```
2024/10/10 01:53:44 sendOrder, &{{bc100da0-b9f3-4991-9679-a7d189986922 bc100da0-b9f3-4991-9679-a7d189986922  0xc00014eb80 1 1 1 1 10 0 1 0001-01-01 00:00:00 +0000 UTC 0 0 []} 0xc0001247e0  {0 0}  }
2024/10/10 01:53:44 sendOrder params: {BTC-PERPETUAL 10 market bc100da0-b9f3-4991-9679-a7d189986922 0 good_til_cancelled <nil> false false 0  }
2024/10/10 01:53:44 Channel: user.trades.any.any.raw [{"liquidity":"T","risk_reducing":false,"order_type":"market","trade_id":"191715010","fee_currency":"BTC","contracts":1.0,"reduce_only":false,"self_trade":false,"post_only":false,"mmp":false,"fee":8e-8,"tick_direction":0,"matching_id":null,"order_id":"28923304722","mark_price":60763.53,"api":true,"trade_seq":113665972,"instrument_name":"BTC-PERPETUAL","profit_loss":0.0,"index_price":60721.31,"direction":"buy","amount":10.0,"price":60810.0,"state":"filled","timestamp":1728525224281,"label":"bc100da0-b9f3-4991-9679-a7d189986922"}]
```
